### PR TITLE
Added check to _SetCertPolicy.ps1 for PS Core support

### DIFF
--- a/PasswordState/Private/_SetCertPolicy.ps1
+++ b/PasswordState/Private/_SetCertPolicy.ps1
@@ -16,7 +16,11 @@ limitations under the License.
 
 function _SetCertPolicy {
     # Allow untrusted SSL certs
-    Add-Type -TypeDefinition @"
+    if ($PSVersionTable.PSEdition -eq 'Core') {
+        $PSDefaultParameterValues.Add("Invoke-RestMethod:SkipCertificateCheck", $true)
+        $PSDefaultParameterValues.Add("Invoke-WebRequest:SkipCertificateCheck", $true)
+    } else {
+        Add-Type -TypeDefinition @"
         using System.Net;
         using System.Security.Cryptography.X509Certificates;
         public class TrustAllCertsPolicy : ICertificatePolicy {
@@ -27,5 +31,6 @@ function _SetCertPolicy {
             }
         }
 "@
-    [System.Net.ServicePointManager]::CertificatePolicy = New-Object -TypeName TrustAllCertsPolicy
+        [System.Net.ServicePointManager]::CertificatePolicy = New-Object -TypeName TrustAllCertsPolicy
+    }
 }


### PR DESCRIPTION
Addeded an if else check for against $PSVersiontable.PSEdition to check if the current edition of PowerShell is Core or Desktop.  PowerShell Core / 6 will add $PSDefaultParameterValues for Invoke-RestMethod and Invoke-WebRequest to always use the "-SkipCertificateCheck" parameter.  PowerShell 5.X and earlier will continue to use the ICertificatePolicy method.

<!--- Provide a general summary of your changes in the Title above -->
Added a check to _SetCertPolicy.ps1 for the PowerShell edition. 

## Description
<!--- Describe your changes in detail -->
_SetCertPolicy.ps1 will check if $PSVersionTable.Edition is 'Core' or 'Desktop'.  It will handle certificate validation accordingly.  PowerShell Core/6 will use $PSDefaultParameterValue for `Invoke-RestMethod` and `Invoke-WebRequest`.  PowerShell Desktop/5.x will continue to use the C# code calling ICertificatePolicy. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Related to issue #7 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This solves the issue where the module was unable to import on PowerShell Core/6 by changing how a private function handles checking certificates.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All existing tests were run prior to commit.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.